### PR TITLE
Feature/apollo client cache config

### DIFF
--- a/client/codegen.yml
+++ b/client/codegen.yml
@@ -4,7 +4,7 @@ generates:
   ./src/app/graphql/graphql-custom-backend.service.ts: # where to generate file
     schema:
       - http://localhost:3000/graphql # where the server lives
-      # - libs/graphql/src/lib/local.schema.graphql # where is our local schema
+      - src/app/graphql/garphql-local-schema/*.graphql # where is our local schema
     documents:
       - src/app/graphql/graphql-custom-backend/*.graphql # where are our queries / mutations, etc.
     plugins:

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,9 @@
 		"@angular/cli": "~14.1.0",
 		"@angular/compiler-cli": "^14.1.0",
 		"@graphql-codegen/cli": "^2.11.5",
+		"@graphql-codegen/typescript": "^2.7.3",
+		"@graphql-codegen/typescript-apollo-angular": "^3.5.3",
+		"@graphql-codegen/typescript-operations": "^2.5.3",
 		"@types/jasmine": "~4.0.0",
 		"jasmine-core": "~4.2.0",
 		"karma": "~6.4.0",
@@ -42,9 +45,6 @@
 		"karma-coverage": "~2.2.0",
 		"karma-jasmine": "~5.1.0",
 		"karma-jasmine-html-reporter": "~2.0.0",
-		"@graphql-codegen/typescript": "^2.7.3",
-		"@graphql-codegen/typescript-apollo-angular": "^3.5.3",
-		"@graphql-codegen/typescript-operations": "^2.5.3",
 		"typescript": "~4.7.2"
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
 		"@angular/router": "^14.1.0",
 		"@apollo/client": "^3.6.9",
 		"apollo-angular": "^3.0.1",
+		"crypto-hash": "^2.0.1",
 		"graphql": "^16.5.0",
 		"rxjs": "~7.5.0",
 		"subscriptions-transport-ws": "^0.11.0",

--- a/client/src/app/core/api/movie-api.service.ts
+++ b/client/src/app/core/api/movie-api.service.ts
@@ -15,6 +15,7 @@ import {
 	MovieInfoFragment,
 	MovieInputCreate,
 	MovieInputEdit,
+	MovieSelectType,
 } from './../../graphql/graphql-custom-backend.service';
 
 @Injectable({
@@ -53,6 +54,7 @@ export class MovieApiService {
 						updatedAt: new Date().toISOString(),
 						title: title,
 						description: description,
+						isSelected: MovieSelectType.Unselected,
 					},
 				},
 				update: (store: DataProxy, { data }) => {

--- a/client/src/app/features/movie/components/movie-card/movie-card.component.html
+++ b/client/src/app/features/movie/components/movie-card/movie-card.component.html
@@ -12,7 +12,7 @@
 	<!-- body -->
 	<mat-card-content>
 		<!-- description normal display -->
-		<div *ngIf="!editing">{{movieInfo.description}}</div>
+		<div *ngIf="!editing" class="description">{{movieInfo.description}}</div>
 
 		<!-- editing form -->
 		<ng-container *ngIf="editing" [formGroup]="form">
@@ -34,7 +34,7 @@
 	<mat-card-actions>
 		<!-- no editing buttons -->
 		<ng-container *ngIf="!editing">
-			<button mat-flat-button color="accent" (click)="onToggleEdit()">Edit</button>
+			<button mat-stroked-button color="primary" (click)="onToggleEdit()">Edit</button>
 			<button mat-flat-button color="warn" (click)="onDeleteMovie()">Delete</button>
 		</ng-container>
 

--- a/client/src/app/features/movie/components/movie-card/movie-card.component.html
+++ b/client/src/app/features/movie/components/movie-card/movie-card.component.html
@@ -1,11 +1,26 @@
 <mat-card>
 	<!-- header -->
 	<mat-card-header>
-		<mat-card-title>[{{movieInfo.id}}] {{ movieInfo.title }}</mat-card-title>
+		<mat-card-title>
+			<!-- title -->
+			<span>[{{movieInfo.id}}] {{ movieInfo.title }}</span>
+
+			<!-- select -->
+			<button mat-icon-button *ngIf="movieInfo.isSelected === MovieSelectType.Unselected" (click)="onSelectChange(true)">
+				<mat-icon>star_border</mat-icon>
+			</button>
+
+			<!-- unselect -->
+			<button mat-icon-button *ngIf="movieInfo.isSelected === MovieSelectType.Selected" (click)="onSelectChange(false)">
+				<mat-icon>star</mat-icon>
+			</button>
+		</mat-card-title>
+
+		<!-- subtitles -->
 		<mat-card-subtitle>
-			<span>Created at: {{ movieInfo.createdAt | date: 'HH:mm, dd.MM.YYYY'}}</span>
+			<span>Created at: {{ movieInfo.createdAt | date: 'HH:mm:ss, dd.MM.YYYY'}}</span>
 			<span>|</span>
-			<span>Upated at: {{ movieInfo.updatedAt | date: 'HH:mm, dd.MM.YYYY'}}</span>
+			<span>Upated at: {{ movieInfo.updatedAt | date: 'HH:mm:ss, dd.MM.YYYY'}}</span>
 		</mat-card-subtitle>
 	</mat-card-header>
 

--- a/client/src/app/features/movie/components/movie-card/movie-card.component.scss
+++ b/client/src/app/features/movie/components/movie-card/movie-card.component.scss
@@ -1,7 +1,23 @@
 :host {
-	mat-card-subtitle {
-		display: flex;
-		gap: 16px;
+	mat-card {
+		mat-card-header {
+			mat-card-title {
+				font-size: 16px;
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				padding: 4px;
+
+				mat-icon {
+					cursor: pointer;
+				}
+			}
+
+			mat-card-subtitle {
+				display: flex;
+				gap: 16px;
+			}
+		}
 	}
 
 	mat-form-field {

--- a/client/src/app/features/movie/components/movie-card/movie-card.component.scss
+++ b/client/src/app/features/movie/components/movie-card/movie-card.component.scss
@@ -8,13 +8,20 @@
 		width: 100%;
 	}
 
+	.description {
+		padding: 16px;
+		background-color: #e5e5e5;
+		border-radius: 8px;
+	}
+
 	mat-card-actions {
 		display: flex;
-		justify-content: end;
-		gap: 16px;
+		flex-flow: row;
+		gap: 8px;
 
 		button {
-			min-width: 140px;
+			width: 90%;
+			margin: auto;
 		}
 	}
 }

--- a/client/src/app/features/movie/components/movie-card/movie-card.component.ts
+++ b/client/src/app/features/movie/components/movie-card/movie-card.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MovieInfoFragment, MovieInputEdit } from 'src/app/graphql/graphql-custom-backend.service';
+import { MovieInfoFragment, MovieInputEdit, MovieSelectType } from 'src/app/graphql/graphql-custom-backend.service';
 
 @Component({
 	selector: 'app-movie-card',
@@ -8,15 +8,19 @@ import { MovieInfoFragment, MovieInputEdit } from 'src/app/graphql/graphql-custo
 	styleUrls: ['./movie-card.component.scss'],
 })
 export class MovieCardComponent implements OnInit {
+	@Output() toggleSelectMovie: EventEmitter<boolean> = new EventEmitter<boolean>();
 	@Output() editMovie: EventEmitter<MovieInputEdit> = new EventEmitter<MovieInputEdit>();
 	@Output() deleteMovie: EventEmitter<number> = new EventEmitter<number>();
 
 	@Input() movieInfo!: MovieInfoFragment;
+	@Input() showSelectMovie = true;
 
 	protected readonly form: FormGroup = this.fb.nonNullable.group({
 		title: ['', [Validators.required]],
 		description: ['', [Validators.required]],
 	});
+
+	MovieSelectType = MovieSelectType;
 
 	editing = false;
 
@@ -52,5 +56,9 @@ export class MovieCardComponent implements OnInit {
 
 	onDeleteMovie(): void {
 		this.deleteMovie.emit(this.movieInfo.id);
+	}
+
+	onSelectChange(inSelected: boolean): void {
+		this.toggleSelectMovie.emit(inSelected);
 	}
 }

--- a/client/src/app/features/movie/components/movie-form/movie-form.component.html
+++ b/client/src/app/features/movie/components/movie-form/movie-form.component.html
@@ -1,7 +1,7 @@
 <mat-card>
 	<!-- header -->
 	<mat-card-header>
-		<mat-card-title>Insert new Movie</mat-card-title>
+		<mat-card-title>{{ title }}</mat-card-title>
 	</mat-card-header>
 
 	<!-- body -->

--- a/client/src/app/features/movie/components/movie-form/movie-form.component.scss
+++ b/client/src/app/features/movie/components/movie-form/movie-form.component.scss
@@ -3,13 +3,18 @@
 		width: 100%;
 	}
 
+	mat-card-header {
+		height: 55px;
+	}
+
 	mat-card-actions {
 		display: flex;
 		justify-content: end;
 		gap: 16px;
 
 		button {
-			min-width: 140px;
+			min-width: 90%;
+			margin: auto;
 		}
 	}
 }

--- a/client/src/app/features/movie/components/movie-form/movie-form.component.ts
+++ b/client/src/app/features/movie/components/movie-form/movie-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MovieInputCreate } from 'src/app/graphql/graphql-custom-backend.service';
 
@@ -8,6 +8,7 @@ import { MovieInputCreate } from 'src/app/graphql/graphql-custom-backend.service
 	styleUrls: ['./movie-form.component.scss'],
 })
 export class MovieFormComponent implements OnInit {
+	@Input() title: string = '';
 	@Output() addMovie: EventEmitter<MovieInputCreate> = new EventEmitter<MovieInputCreate>();
 
 	protected readonly form: FormGroup = this.fb.nonNullable.group({

--- a/client/src/app/features/movie/models/movie.model.ts
+++ b/client/src/app/features/movie/models/movie.model.ts
@@ -1,0 +1,4 @@
+import { makeVar } from '@apollo/client/core';
+import { MovieInfoFragment } from 'src/app/graphql/graphql-custom-backend.service';
+
+export const localMoviesReactiveVars = makeVar<MovieInfoFragment[]>([]);

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.html
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.html
@@ -22,6 +22,7 @@
 			[movieInfo]="movieInfo"
 			(deleteMovie)="onMovieDeleteToServer($event)"
 			(editMovie)="onEditMovieToServer($event)"
+			(toggleSelectMovie)="onToggleSelectMovie(movieInfo, $event)"
 		></app-movie-card>
 	</div>
 
@@ -44,6 +45,7 @@
 			[movieInfo]="movieInfo"
 			(deleteMovie)="onMovieDeleteToApolloCache($event)"
 			(editMovie)="onMovieEditToApolloCache($event)"
+			(toggleSelectMovie)="onToggleSelectMovie(movieInfo, $event)"
 		></app-movie-card>
 	</div>
 </div>

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.html
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.html
@@ -15,7 +15,7 @@
 <h1>Movie list</h1>
 <div class="wrapper-grid">
 	<!-- movies persisted on the backend -->
-	<div *ngIf="movies$ | async as movies" class="wrapper-movie">
+	<div *ngIf="moviesFromServer$ | async as movies" class="wrapper-movie">
 		<h3>Movies persisted on the backend</h3>
 		<app-movie-card
 			*ngFor="let movieInfo of movies"
@@ -26,8 +26,8 @@
 	</div>
 
 	<!-- Persited movie localy in reactive variables -->
-	<div *ngIf="movies$ | async as movies" class="wrapper-movie">
-		<h3>Persed movie localy in reactive variables</h3>
+	<div *ngIf="moviesFromReactiveVariables$ | async as movies" class="wrapper-movie">
+		<h3>Persited movie localy in reactive variables</h3>
 		<app-movie-card
 			*ngFor="let movieInfo of movies"
 			[movieInfo]="movieInfo"
@@ -37,8 +37,8 @@
 	</div>
 
 	<!-- Persisted movie locally in Apollo Cache -->
-	<div *ngIf="movies$ | async as movies" class="wrapper-movie">
-		<h3>Persisted movie locally in Apollo Cache</h3>
+	<div *ngIf="moviesFromApolloCache$ | async as movies" class="wrapper-movie">
+		<h3>Persited movie locally in Apollo Cache</h3>
 		<app-movie-card
 			*ngFor="let movieInfo of movies"
 			[movieInfo]="movieInfo"

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.html
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.html
@@ -1,13 +1,49 @@
 <!-- show create movie form -->
-<app-movie-form (addMovie)="onMovieAdd($event)"></app-movie-form>
+<div class="wrapper-grid">
+	<!-- form to persis movie on the backend -->
+	<app-movie-form title="Send movie to the Backend" (addMovie)="onMovieAddToServer($event)"></app-movie-form>
+	<!-- form to persist movie in reactive variables -->
+	<app-movie-form
+		title="Persit movie localy in reactive variables"
+		(addMovie)="onMovieAddToReactiveVariables($event)"
+	></app-movie-form>
+	<!-- form to persis movies in graphql cache, persist on reload -->
+	<app-movie-form title="Persist movie locally in Apollo Cache" (addMovie)="onMovieAddToApolloCache($event)"></app-movie-form>
+</div>
 
 <!-- list movies -->
 <h1>Movie list</h1>
-<ng-container *ngIf="movies$ | async as movies">
-	<app-movie-card
-		*ngFor="let movieInfo of movies"
-		[movieInfo]="movieInfo"
-		(deleteMovie)="onMovieDelete($event)"
-		(editMovie)="onEditMovie($event)"
-	></app-movie-card>
-</ng-container>
+<div class="wrapper-grid">
+	<!-- movies persisted on the backend -->
+	<div *ngIf="movies$ | async as movies" class="wrapper-movie">
+		<h3>Movies persisted on the backend</h3>
+		<app-movie-card
+			*ngFor="let movieInfo of movies"
+			[movieInfo]="movieInfo"
+			(deleteMovie)="onMovieDeleteToServer($event)"
+			(editMovie)="onEditMovieToServer($event)"
+		></app-movie-card>
+	</div>
+
+	<!-- Persited movie localy in reactive variables -->
+	<div *ngIf="movies$ | async as movies" class="wrapper-movie">
+		<h3>Persed movie localy in reactive variables</h3>
+		<app-movie-card
+			*ngFor="let movieInfo of movies"
+			[movieInfo]="movieInfo"
+			(deleteMovie)="onMovieDeleteToReactiveVariables($event)"
+			(editMovie)="onMovieEditToReactiveVariables($event)"
+		></app-movie-card>
+	</div>
+
+	<!-- Persisted movie locally in Apollo Cache -->
+	<div *ngIf="movies$ | async as movies" class="wrapper-movie">
+		<h3>Persisted movie locally in Apollo Cache</h3>
+		<app-movie-card
+			*ngFor="let movieInfo of movies"
+			[movieInfo]="movieInfo"
+			(deleteMovie)="onMovieDeleteToApolloCache($event)"
+			(editMovie)="onMovieEditToApolloCache($event)"
+		></app-movie-card>
+	</div>
+</div>

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.scss
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.scss
@@ -2,7 +2,34 @@
 	display: flex;
 	flex-flow: column;
 	gap: 16px;
-	width: 70%;
+	width: 90%;
 	margin: auto;
 	padding: 16px;
+
+	.wrapper-grid {
+		display: grid;
+		grid-template-columns: auto auto auto;
+		gap: 16px;
+
+		@media (max-width: 992px) {
+			grid-template-columns: auto;
+		}
+	}
+
+	h3 {
+		font-size: 20px;
+		font-weight: 500;
+		color: #4050b5;
+		margin-bottom: 0;
+		background-color: #e5e5e5;
+		padding: 4px;
+		border-radius: 8px;
+		text-align: center;
+	}
+
+	.wrapper-movie {
+		display: flex;
+		flex-flow: column;
+		gap: 16px;
+	}
 }

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.scss
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.scss
@@ -8,7 +8,7 @@
 
 	.wrapper-grid {
 		display: grid;
-		grid-template-columns: auto auto auto;
+		grid-template-columns: repeat(3, 1fr);
 		gap: 16px;
 
 		@media (max-width: 992px) {

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
@@ -16,15 +16,30 @@ export class MovieListComponent implements OnInit {
 		this.movies$ = this.movieApiService.getAllMovies();
 	}
 
-	async onMovieAdd(movieInputCreate: MovieInputCreate): Promise<void> {
+	/* Methods to manage Movie on backend */
+	async onMovieAddToServer(movieInputCreate: MovieInputCreate): Promise<void> {
 		await firstValueFrom(this.movieApiService.createMovie(movieInputCreate));
 	}
 
-	async onEditMovie(movieInputEdit: MovieInputEdit): Promise<void> {
+	async onEditMovieToServer(movieInputEdit: MovieInputEdit): Promise<void> {
 		await firstValueFrom(this.movieApiService.editMovie(movieInputEdit));
 	}
 
-	async onMovieDelete(movieId: number): Promise<void> {
+	async onMovieDeleteToServer(movieId: number): Promise<void> {
 		await firstValueFrom(this.movieApiService.deleteMovie(movieId));
 	}
+
+	/* Methods to manage Movie in reactive variables */
+	onMovieAddToReactiveVariables(movieInputCreate: MovieInputCreate): void {}
+
+	onMovieEditToReactiveVariables(movieInputEdit: MovieInputEdit): void {}
+
+	onMovieDeleteToReactiveVariables(movieId: number): void {}
+
+	/* Methods to manage Movie in Apollo cache */
+	onMovieAddToApolloCache(movieInputCreate: MovieInputCreate): void {}
+
+	onMovieEditToApolloCache(movieInputEdit: MovieInputEdit): void {}
+
+	onMovieDeleteToApolloCache(movieId: number): void {}
 }

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
@@ -19,8 +19,6 @@ export class MovieListComponent implements OnInit {
 		this.moviesFromServer$ = this.movieApiService.getAllMovies();
 		this.moviesFromReactiveVariables$ = this.movieLocalService.getAllLocalMoviesReactiveVars();
 		this.moviesFromApolloCache$ = this.movieLocalService.getAllLocalMovies();
-
-		this.moviesFromServer$.subscribe((x) => console.log(x));
 	}
 
 	/* Methods to manage Movie on backend */

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { firstValueFrom, Observable } from 'rxjs';
 import { MovieApiService } from 'src/app/core/api/movie-api.service';
 import { MovieInfoFragment, MovieInputCreate, MovieInputEdit } from 'src/app/graphql/graphql-custom-backend.service';
+import { MovieLocalService } from '../../services/movie-local.service';
 
 @Component({
 	selector: 'app-movie-list',
@@ -9,11 +10,15 @@ import { MovieInfoFragment, MovieInputCreate, MovieInputEdit } from 'src/app/gra
 	styleUrls: ['./movie-list.component.scss'],
 })
 export class MovieListComponent implements OnInit {
-	movies$!: Observable<MovieInfoFragment[]>;
-	constructor(private movieApiService: MovieApiService) {}
+	moviesFromServer$!: Observable<MovieInfoFragment[]>;
+	moviesFromReactiveVariables$!: Observable<MovieInfoFragment[]>;
+	moviesFromApolloCache$!: Observable<MovieInfoFragment[]>;
+	constructor(private movieApiService: MovieApiService, private movieLocalService: MovieLocalService) {}
 
 	ngOnInit(): void {
-		this.movies$ = this.movieApiService.getAllMovies();
+		this.moviesFromServer$ = this.movieApiService.getAllMovies();
+		this.moviesFromReactiveVariables$ = this.movieLocalService.getAllLocalMoviesReactiveVars();
+		this.moviesFromApolloCache$ = this.movieLocalService.getAllLocalMovies();
 	}
 
 	/* Methods to manage Movie on backend */
@@ -30,16 +35,28 @@ export class MovieListComponent implements OnInit {
 	}
 
 	/* Methods to manage Movie in reactive variables */
-	onMovieAddToReactiveVariables(movieInputCreate: MovieInputCreate): void {}
+	onMovieAddToReactiveVariables(movieInputCreate: MovieInputCreate): void {
+		this.movieLocalService.onMovieAddToReactiveVariables(movieInputCreate);
+	}
 
-	onMovieEditToReactiveVariables(movieInputEdit: MovieInputEdit): void {}
+	onMovieEditToReactiveVariables(movieInputEdit: MovieInputEdit): void {
+		this.movieLocalService.onMovieEditToReactiveVariables(movieInputEdit);
+	}
 
-	onMovieDeleteToReactiveVariables(movieId: number): void {}
+	onMovieDeleteToReactiveVariables(movieId: number): void {
+		this.movieLocalService.onMovieDeleteToReactiveVariables(movieId);
+	}
 
 	/* Methods to manage Movie in Apollo cache */
-	onMovieAddToApolloCache(movieInputCreate: MovieInputCreate): void {}
+	onMovieAddToApolloCache(movieInputCreate: MovieInputCreate): void {
+		this.movieLocalService.onMovieAddToApolloCache(movieInputCreate);
+	}
 
-	onMovieEditToApolloCache(movieInputEdit: MovieInputEdit): void {}
+	onMovieEditToApolloCache(movieInputEdit: MovieInputEdit): void {
+		this.movieLocalService.onMovieEditToApolloCache(movieInputEdit);
+	}
 
-	onMovieDeleteToApolloCache(movieId: number): void {}
+	onMovieDeleteToApolloCache(movieId: number): void {
+		this.movieLocalService.onMovieDeleteToApolloCache(movieId);
+	}
 }

--- a/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
+++ b/client/src/app/features/movie/pages/movie-list/movie-list.component.ts
@@ -19,6 +19,8 @@ export class MovieListComponent implements OnInit {
 		this.moviesFromServer$ = this.movieApiService.getAllMovies();
 		this.moviesFromReactiveVariables$ = this.movieLocalService.getAllLocalMoviesReactiveVars();
 		this.moviesFromApolloCache$ = this.movieLocalService.getAllLocalMovies();
+
+		this.moviesFromServer$.subscribe((x) => console.log(x));
 	}
 
 	/* Methods to manage Movie on backend */
@@ -58,5 +60,10 @@ export class MovieListComponent implements OnInit {
 
 	onMovieDeleteToApolloCache(movieId: number): void {
 		this.movieLocalService.onMovieDeleteToApolloCache(movieId);
+	}
+
+	/* Additional functionality */
+	onToggleSelectMovie(movie: MovieInfoFragment, isSelected: boolean): void {
+		this.movieLocalService.onToggleSelectMovie(movie, isSelected);
 	}
 }

--- a/client/src/app/features/movie/services/movie-local.service.ts
+++ b/client/src/app/features/movie/services/movie-local.service.ts
@@ -4,6 +4,7 @@ import { map, Observable } from 'rxjs';
 import {
 	GetAllLocalMoviesQuery,
 	MovieInfoFragment,
+	MovieInfoFragmentDoc,
 	MovieInputCreate,
 	MovieInputEdit,
 	MovieSelectType,
@@ -39,8 +40,10 @@ export class MovieLocalService {
 	onMovieEditToReactiveVariables({ id, title, description }: MovieInputEdit): void {
 		// find index of the edited movie
 		const editedMovieIndex = localMoviesReactiveVars().findIndex((movie) => movie.id === id);
+
 		// get the edited movie by index
 		const editedMovie = localMoviesReactiveVars()[editedMovieIndex];
+
 		// create new array where we replace the old movie title & description
 		const editedArray = Object.assign([], localMoviesReactiveVars(), {
 			[editedMovieIndex]: {
@@ -50,6 +53,7 @@ export class MovieLocalService {
 				updatedAt: new Date().toISOString(),
 			},
 		});
+
 		// save whole array of movies into reactive vars
 		localMoviesReactiveVars(editedArray);
 	}
@@ -85,6 +89,7 @@ export class MovieLocalService {
 		// find index of the edited movie
 		const editedMovieIndex = getAllLocalMovies.findIndex((movie) => movie.id === id);
 
+		// editedMovieIndex can be 0, so check only for undefined
 		if (editedMovieIndex !== undefined) {
 			// get the edited movie by index
 			const editedMovie = getAllLocalMovies[editedMovieIndex];
@@ -113,6 +118,36 @@ export class MovieLocalService {
 
 		// update cache with rest of the movies
 		this.updateGetAllLocalMoviesQuery(cachedMoviesFiltered);
+	}
+
+	onToggleSelectMovie(movie: MovieInfoFragment, isSelected: boolean): void {
+		// These two are the same
+
+		// this.apollo.client.cache.updateFragment<MovieInfoFragment>(
+		// 	{
+		// 		fragment: MovieInfoFragmentDoc,
+		// 	},
+		// 	() => ({
+		// 		__typename: 'Movie',
+		// 		id: movie.id,
+		// 		title: movie.title,
+		// 		createdAt: movie.createdAt,
+		// 		description: movie.description,
+		// 		updatedAt: new Date().toISOString(),
+		// 		isSelected: isSelected ? MovieSelectType.Selected : MovieSelectType.Unselected,
+		// 	})
+		// );
+
+		this.apollo.client.writeFragment<MovieInfoFragment>({
+			id: `${movie.__typename}:${movie.id}`,
+			fragment: MovieInfoFragmentDoc,
+			fragmentName: 'MovieInfo',
+			data: {
+				...movie,
+				isSelected: isSelected ? MovieSelectType.Selected : MovieSelectType.Unselected,
+				updatedAt: new Date().toISOString(),
+			},
+		});
 	}
 
 	/* --------------------------------------- */

--- a/client/src/app/features/movie/services/movie-local.service.ts
+++ b/client/src/app/features/movie/services/movie-local.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+import { MovieInfoFragment } from 'src/app/graphql/graphql-custom-backend.service';
+import { localMoviesReactiveVars } from '../models/movie.model';
+import { GetAllLocalMoviesReactiveVarsGQL } from './../../../graphql/graphql-custom-backend.service';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class MovieLocalService {
+	constructor(private getAllLocalMoviesReactiveVarsGQL: GetAllLocalMoviesReactiveVarsGQL) {}
+
+	getAllLocalMoviesReactiveVars(): Observable<MovieInfoFragment[]> {
+		// return localMoviesReactiveVars()]); // <-- this also works
+		return this.getAllLocalMoviesReactiveVarsGQL.watch().valueChanges.pipe(map((res) => res.data.getAllLocalMoviesReactiveVars));
+	}
+
+	addMovieIntoLocalMoviesReactiveVars(movie: MovieInfoFragment): void {
+		localMoviesReactiveVars([movie, ...localMoviesReactiveVars()]);
+	}
+}

--- a/client/src/app/graphql/garphql-local-schema/local.schema.graphql
+++ b/client/src/app/graphql/garphql-local-schema/local.schema.graphql
@@ -1,0 +1,13 @@
+extend type Query {
+	getAllLocalMovies: [Movie!]!
+	getAllLocalMoviesReactiveVars: [Movie!]!
+}
+
+enum MovieSelectType {
+	isSelected
+	UNSELECTED
+}
+
+extend type Movie {
+	isSelected: MovieSelectType!
+}

--- a/client/src/app/graphql/garphql-local-schema/local.schema.graphql
+++ b/client/src/app/graphql/garphql-local-schema/local.schema.graphql
@@ -4,7 +4,7 @@ extend type Query {
 }
 
 enum MovieSelectType {
-	isSelected
+	SELECTED
 	UNSELECTED
 }
 

--- a/client/src/app/graphql/graphql-custom-backend.service.ts
+++ b/client/src/app/graphql/graphql-custom-backend.service.ts
@@ -77,8 +77,8 @@ export type MovieInputEdit = {
 };
 
 export enum MovieSelectType {
-  Unselected = 'UNSELECTED',
-  IsSelected = 'isSelected'
+  Selected = 'SELECTED',
+  Unselected = 'UNSELECTED'
 }
 
 export type Mutation = {

--- a/client/src/app/graphql/graphql-custom-backend.service.ts
+++ b/client/src/app/graphql/graphql-custom-backend.service.ts
@@ -21,6 +21,7 @@ export type Movie = {
   /** User's description to the movie */
   description?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
+  isSelected: MovieSelectType;
   movieComment: Array<MovieComment>;
   /** User's title to the movie */
   title: Scalars['String'];
@@ -75,6 +76,11 @@ export type MovieInputEdit = {
   title: Scalars['String'];
 };
 
+export enum MovieSelectType {
+  Unselected = 'UNSELECTED',
+  IsSelected = 'isSelected'
+}
+
 export type Mutation = {
   __typename?: 'Mutation';
   createMovie: Movie;
@@ -105,6 +111,8 @@ export type MutationEditMovieArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  getAllLocalMovies: Array<Movie>;
+  getAllLocalMoviesReactiveVars: Array<Movie>;
   /** we return multiple movies */
   getAllMovies: Array<Movie>;
   getAllUsers: Array<User>;
@@ -141,26 +149,36 @@ export type User = {
   username: Scalars['String'];
 };
 
-export type MovieInfoFragment = { __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null };
+export type GetAllLocalMoviesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAllLocalMoviesQuery = { __typename?: 'Query', getAllLocalMovies: Array<{ __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null, isSelected: MovieSelectType }> };
+
+export type GetAllLocalMoviesReactiveVarsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAllLocalMoviesReactiveVarsQuery = { __typename?: 'Query', getAllLocalMoviesReactiveVars: Array<{ __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null, isSelected: MovieSelectType }> };
+
+export type MovieInfoFragment = { __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null, isSelected: MovieSelectType };
 
 export type GetAllMoviesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllMoviesQuery = { __typename?: 'Query', getAllMovies: Array<{ __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null }> };
+export type GetAllMoviesQuery = { __typename?: 'Query', getAllMovies: Array<{ __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null, isSelected: MovieSelectType }> };
 
 export type CreateMovieMutationVariables = Exact<{
   movieInputCreate: MovieInputCreate;
 }>;
 
 
-export type CreateMovieMutation = { __typename?: 'Mutation', createMovie: { __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null } };
+export type CreateMovieMutation = { __typename?: 'Mutation', createMovie: { __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null, isSelected: MovieSelectType } };
 
 export type EditMovieMutationVariables = Exact<{
   movieInputEdit: MovieInputEdit;
 }>;
 
 
-export type EditMovieMutation = { __typename?: 'Mutation', editMovie: { __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null } };
+export type EditMovieMutation = { __typename?: 'Mutation', editMovie: { __typename?: 'Movie', id: number, createdAt: string, updatedAt: string, title: string, description?: string | null, isSelected: MovieSelectType } };
 
 export type DeleteMovieMutationVariables = Exact<{
   movieId: Scalars['Int'];
@@ -176,8 +194,45 @@ export const MovieInfoFragmentDoc = gql`
   updatedAt
   title
   description
+  isSelected @client
 }
     `;
+export const GetAllLocalMoviesDocument = gql`
+    query GetAllLocalMovies {
+  getAllLocalMovies @client {
+    ...MovieInfo
+  }
+}
+    ${MovieInfoFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class GetAllLocalMoviesGQL extends Apollo.Query<GetAllLocalMoviesQuery, GetAllLocalMoviesQueryVariables> {
+    override document = GetAllLocalMoviesDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const GetAllLocalMoviesReactiveVarsDocument = gql`
+    query GetAllLocalMoviesReactiveVars {
+  getAllLocalMoviesReactiveVars @client {
+    ...MovieInfo
+  }
+}
+    ${MovieInfoFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class GetAllLocalMoviesReactiveVarsGQL extends Apollo.Query<GetAllLocalMoviesReactiveVarsQuery, GetAllLocalMoviesReactiveVarsQueryVariables> {
+    override document = GetAllLocalMoviesReactiveVarsDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
 export const GetAllMoviesDocument = gql`
     query GetAllMovies {
   getAllMovies {

--- a/client/src/app/graphql/graphql-custom-backend/movie-local.graphql
+++ b/client/src/app/graphql/graphql-custom-backend/movie-local.graphql
@@ -1,0 +1,11 @@
+query GetAllLocalMovies {
+	getAllLocalMovies @client {
+		...MovieInfo
+	}
+}
+
+query GetAllLocalMoviesReactiveVars {
+	getAllLocalMoviesReactiveVars @client {
+		...MovieInfo
+	}
+}

--- a/client/src/app/graphql/graphql-custom-backend/movie.graphql
+++ b/client/src/app/graphql/graphql-custom-backend/movie.graphql
@@ -4,6 +4,7 @@ fragment MovieInfo on Movie {
 	updatedAt
 	title
 	description
+	isSelected @client
 }
 
 query GetAllMovies {

--- a/client/src/app/graphql/graphql.module.ts
+++ b/client/src/app/graphql/graphql.module.ts
@@ -143,6 +143,12 @@ export function createDefaultApollo(httpLink: HttpLink): ApolloClientOptions<any
 		http
 	);
 
+	// Getting error -> 1 import { ApolloCache } from '@apollo/client/core';
+	// persistCache({
+	// 	cache,
+	// 	storage: new LocalStorageWrapper(window.localStorage),
+	// });
+
 	const config: ApolloClientOptions<any> = {
 		connectToDevTools: !environment.production,
 		assumeImmutableResults: true,

--- a/client/src/app/graphql/graphql.module.ts
+++ b/client/src/app/graphql/graphql.module.ts
@@ -11,6 +11,7 @@ import { HttpLink } from 'apollo-angular/http';
 import { environment } from 'src/environments/environment';
 import { localMoviesReactiveVars } from '../features/movie/models/movie.model';
 import { DialogService } from '../shared/services/dialog-service.service';
+import { MovieInfoFragment } from './graphql-custom-backend.service';
 
 /*
   how to use multiple endpoints: https://stackoverflow.com/questions/56212486/connect-an-angular-app-to-multiple-apollo-clients
@@ -90,6 +91,18 @@ export function createDefaultApollo(httpLink: HttpLink): ApolloClientOptions<any
 					getAllLocalMoviesReactiveVars: {
 						read() {
 							return localMoviesReactiveVars();
+						},
+					},
+					getAllLocalMovies: {
+						read(data: MovieInfoFragment[] | undefined, { variables }) {
+							return data ?? [];
+						},
+						merge(existing: MovieInfoFragment[] = [], incoming: MovieInfoFragment | MovieInfoFragment[]) {
+							// if array is passed, ignore already saved movies
+							if (Array.isArray(incoming)) {
+								return [...incoming];
+							}
+							return [incoming, ...existing];
 						},
 					},
 				},

--- a/client/src/app/graphql/graphql.module.ts
+++ b/client/src/app/graphql/graphql.module.ts
@@ -9,6 +9,7 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { ApolloModule, APOLLO_NAMED_OPTIONS, APOLLO_OPTIONS } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
 import { environment } from 'src/environments/environment';
+import { localMoviesReactiveVars } from '../features/movie/models/movie.model';
 import { DialogService } from '../shared/services/dialog-service.service';
 
 /*
@@ -57,18 +58,41 @@ const basicContext = setContext((_, { headers }) => {
 
 export function createDefaultApollo(httpLink: HttpLink): ApolloClientOptions<any> {
 	const cache = new InMemoryCache({
+		// TODO - missing type safety
 		// dataIdFromObject(responseObject) {
 		// 	switch (responseObject.__typename) {
-		// 		case 'AsteriskQueueTable':
-		// 			return `AsteriskQueueTable:${responseObject.name}`;
+		// 		case 'Movie':
+		// 			return `Movie:${responseObject.id}`;
 		// 		default:
 		// 			return defaultDataIdFromObject(responseObject);
 		// 	}
 		// },
+
 		typePolicies: {
+			Movie: {
+				// keyFields: ['title', 'id'], // to change Movie indentification in cachce
+				fields: {
+					title: {
+						read(title: string) {
+							return title.toUpperCase();
+						},
+					},
+					isSelected: {
+						read() {
+							return false;
+						},
+					},
+				},
+			},
 			Query: {
 				queryType: true,
-				fields: {},
+				fields: {
+					getAllLocalMoviesReactiveVars: {
+						read() {
+							return localMoviesReactiveVars();
+						},
+					},
+				},
 			},
 		},
 	});

--- a/client/src/app/shared/custom-material-module.module.ts
+++ b/client/src/app/shared/custom-material-module.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-const modules = [MatSnackBarModule, MatCardModule, MatIconModule, MatButtonModule, MatInputModule];
+const modules = [MatSnackBarModule, MatCardModule, MatIconModule, MatButtonModule, MatInputModule, MatCheckboxModule];
 
 @NgModule({
 	declarations: [],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "apollo3-cache-persist": "^0.14.1"
+  }
+}

--- a/server/src/modules/movie/movie.service.ts
+++ b/server/src/modules/movie/movie.service.ts
@@ -19,27 +19,27 @@ export class MovieService {
 		});
 	}
 
-	async createMovie(movieInputCreate: MovieInputCreate): Promise<Movie> {
+	async createMovie({ title, description }: MovieInputCreate): Promise<Movie> {
 		return this.prisma.movie.create({
 			data: {
-				title: movieInputCreate.title,
-				description: movieInputCreate.description,
+				title,
+				description,
 			},
 		});
 	}
 
-	async editMovie(movieInputEdit: MovieInputEdit): Promise<Movie> {
+	async editMovie({ id, title, description }: MovieInputEdit): Promise<Movie> {
 		return this.prisma.movie.upsert({
 			update: {
-				title: movieInputEdit.title,
-				description: movieInputEdit.description,
+				title,
+				description,
 			},
 			create: {
-				title: movieInputEdit.title,
-				description: movieInputEdit.description,
+				title,
+				description,
 			},
 			where: {
-				id: movieInputEdit.id,
+				id,
 			},
 		});
 	}


### PR DESCRIPTION
- [x] Extend external server schema with local variable isSelected
- [x] User the local variable isSelected in the App
- [x] Create local query `getAllLocalMoviesReactiveVars` using reactive variables
- [x] Create local query `getAllLocalMovies`  without reactive variable by standard mode
- [ ] Persist queries on reload 
- [x] Add different identification key for `Movie` type in `dataIdFromObject` 